### PR TITLE
Advanced use action factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ a Changelog](https://keepachangelog.com/en/1.0.0/) and the project adheres to
 Added:
 - Support for older browsers (back through IE 11, currently untested).
 - Dispatch return values in generator `yield` expressions.
+- `createAction.factory(...)` for fine-grained control in generators.
 
 Changed:
 - Enabled several compiler optimizations for smaller bundles.

--- a/src/actions/__tests__/action-factory.test.ts
+++ b/src/actions/__tests__/action-factory.test.ts
@@ -1,4 +1,4 @@
-import actionFactory from '../action-factory';
+import actionFactory, { ACTION_TYPE } from '../action-factory';
 import { expectType } from '../../types/assertions';
 import {
   isActionSuccess,
@@ -7,6 +7,12 @@ import {
 } from '../../utils/action-variant';
 
 describe('actionFactory', () => {
+  it('attaches the action type to a secret field', () => {
+    const factory = actionFactory('action-type');
+
+    expect(factory[ACTION_TYPE]).toBe('action-type');
+  });
+
   it('returns the correct action type', () => {
     const actionType = 'pod-bay-doors/open';
     const fire = actionFactory<void, void>(actionType);

--- a/src/actions/__tests__/action-factory.test.ts
+++ b/src/actions/__tests__/action-factory.test.ts
@@ -1,0 +1,52 @@
+import actionFactory from '../action-factory';
+import { expectType } from '../../types/assertions';
+import {
+  isActionSuccess,
+  isActionFailure,
+  isOptimisticAction,
+} from '../../utils/action-variant';
+
+describe('actionFactory', () => {
+  it('returns the correct action type', () => {
+    const actionType = 'pod-bay-doors/open';
+    const fire = actionFactory<void, void>(actionType);
+
+    expect(fire.optimistic()).toHaveProperty('type', actionType);
+    expect(fire.success()).toHaveProperty('type', actionType);
+    expect(fire.failure(null)).toHaveProperty('type', actionType);
+  });
+
+  describe('success', () => {
+    it('returns a plain action with a payload', () => {
+      const fire = actionFactory<string>('fire');
+      const action = fire.success('payload');
+
+      expect(isActionSuccess(action)).toBe(true);
+      expect(action.payload).toBe('payload');
+      expectType<string>(action.payload);
+    });
+  });
+
+  describe('failure', () => {
+    it('returns an unknown payload type', () => {
+      const fire = actionFactory<string>('fire');
+      const error = new Error('testing factory errors');
+      const action = fire.failure(error);
+
+      expect(isActionFailure(action)).toBe(true);
+      expect(action.payload).toBe(error);
+      expectType<unknown>(action.payload);
+    });
+  });
+
+  describe('optimistic', () => {
+    it('returns the right payload and meta type', () => {
+      const fire = actionFactory<string, number>('fire');
+      const action = fire.optimistic(500);
+
+      expect(isOptimisticAction(action)).toBe(true);
+      expect(action.payload).toBe(500);
+      expectType<number>(action.payload);
+    });
+  });
+});

--- a/src/actions/__tests__/action-factory.test.ts
+++ b/src/actions/__tests__/action-factory.test.ts
@@ -1,4 +1,4 @@
-import actionFactory, { ACTION_TYPE } from '../action-factory';
+import createActionFactory, { ACTION_TYPE } from '../action-factory';
 import { expectType } from '../../types/assertions';
 import {
   isActionSuccess,
@@ -6,16 +6,16 @@ import {
   isOptimisticAction,
 } from '../../utils/action-variant';
 
-describe('actionFactory', () => {
+describe('createActionFactory', () => {
   it('attaches the action type to a secret field', () => {
-    const factory = actionFactory('action-type');
+    const factory = createActionFactory('action-type');
 
     expect(factory[ACTION_TYPE]).toBe('action-type');
   });
 
   it('returns the correct action type', () => {
     const actionType = 'pod-bay-doors/open';
-    const fire = actionFactory<void, void>(actionType);
+    const fire = createActionFactory<void, void>(actionType);
 
     expect(fire.optimistic()).toHaveProperty('type', actionType);
     expect(fire.success()).toHaveProperty('type', actionType);
@@ -24,7 +24,7 @@ describe('actionFactory', () => {
 
   describe('success', () => {
     it('returns a plain action with a payload', () => {
-      const fire = actionFactory<string>('fire');
+      const fire = createActionFactory<string>('fire');
       const action = fire.success('payload');
 
       expect(isActionSuccess(action)).toBe(true);
@@ -35,7 +35,7 @@ describe('actionFactory', () => {
 
   describe('failure', () => {
     it('returns an unknown payload type', () => {
-      const fire = actionFactory<string>('fire');
+      const fire = createActionFactory<string>('fire');
       const error = new Error('testing factory errors');
       const action = fire.failure(error);
 
@@ -47,7 +47,7 @@ describe('actionFactory', () => {
 
   describe('optimistic', () => {
     it('returns the right payload and meta type', () => {
-      const fire = actionFactory<string, number>('fire');
+      const fire = createActionFactory<string, number>('fire');
       const action = fire.optimistic(500);
 
       expect(isOptimisticAction(action)).toBe(true);

--- a/src/actions/action-factory.ts
+++ b/src/actions/action-factory.ts
@@ -1,0 +1,54 @@
+import Phase from '../constants/phase';
+import {
+  ActionConstant,
+  ActionSuccess,
+  ActionFailure,
+  OptimisticAction,
+} from '../types/actions';
+
+/**
+ * ADVANCED: Create plain actions without binding effects. Allows explicitly
+ * dispatching actions while preserving type signatures in reducers.
+ * @param actionType The redux action type.
+ *
+ * @example
+ * createAction.factory<SuccessType, OptimisticType>('load')
+ */
+export default function actionFactory<
+  SuccessPayload = never,
+  OptimisticPayload = never
+>(actionType: ActionConstant) {
+  return {
+    /**
+     * Signifies success and the end of the action.
+     */
+    success: (payload: SuccessPayload): ActionSuccess<SuccessPayload> => ({
+      type: actionType,
+      payload,
+    }),
+
+    /**
+     * Signifies permanent failure. The payload type is always unknown because
+     * anything can go wrong.
+     */
+    failure: (error: unknown): ActionFailure<unknown> => ({
+      type: actionType,
+      error: true,
+      payload: error,
+    }),
+
+    /**
+     * Signifies the start of a long-running task. Can be emitted multiple
+     * times to provide progress updates.
+     */
+    optimistic: (
+      payload: OptimisticPayload,
+    ): OptimisticAction<OptimisticPayload> => ({
+      type: actionType,
+      payload,
+      meta: {
+        phase: Phase.Optimistic,
+      },
+    }),
+  };
+}

--- a/src/actions/action-factory.ts
+++ b/src/actions/action-factory.ts
@@ -14,7 +14,7 @@ import {
  * @example
  * createAction.factory<SuccessType, OptimisticType>('load')
  */
-export default function actionFactory<
+export default function createActionFactory<
   SuccessPayload = never,
   OptimisticPayload = never
 >(

--- a/src/actions/action-factory.ts
+++ b/src/actions/action-factory.ts
@@ -21,6 +21,8 @@ export default function actionFactory<
   actionType: ActionConstant,
 ): ActionFactory<SuccessPayload, OptimisticPayload> {
   return {
+    [ACTION_TYPE]: actionType,
+
     /**
      * Signifies success and the end of the action.
      */
@@ -53,6 +55,8 @@ export default function actionFactory<
   };
 }
 
+export const ACTION_TYPE = Symbol('retreon:action-type');
+
 export interface ActionFactory<SuccessPayload, OptimisticPayload> {
   /**
    * Signifies success and the end of the action.
@@ -70,4 +74,6 @@ export interface ActionFactory<SuccessPayload, OptimisticPayload> {
    * times to provide progress updates.
    */
   optimistic(payload: OptimisticPayload): OptimisticAction<OptimisticPayload>;
+
+  [ACTION_TYPE]: string;
 }

--- a/src/actions/action-factory.ts
+++ b/src/actions/action-factory.ts
@@ -17,12 +17,14 @@ import {
 export default function actionFactory<
   SuccessPayload = never,
   OptimisticPayload = never
->(actionType: ActionConstant) {
+>(
+  actionType: ActionConstant,
+): ActionFactory<SuccessPayload, OptimisticPayload> {
   return {
     /**
      * Signifies success and the end of the action.
      */
-    success: (payload: SuccessPayload): ActionSuccess<SuccessPayload> => ({
+    success: (payload) => ({
       type: actionType,
       payload,
     }),
@@ -31,7 +33,7 @@ export default function actionFactory<
      * Signifies permanent failure. The payload type is always unknown because
      * anything can go wrong.
      */
-    failure: (error: unknown): ActionFailure<unknown> => ({
+    failure: (error) => ({
       type: actionType,
       error: true,
       payload: error,
@@ -41,9 +43,7 @@ export default function actionFactory<
      * Signifies the start of a long-running task. Can be emitted multiple
      * times to provide progress updates.
      */
-    optimistic: (
-      payload: OptimisticPayload,
-    ): OptimisticAction<OptimisticPayload> => ({
+    optimistic: (payload) => ({
       type: actionType,
       payload,
       meta: {
@@ -51,4 +51,23 @@ export default function actionFactory<
       },
     }),
   };
+}
+
+export interface ActionFactory<SuccessPayload, OptimisticPayload> {
+  /**
+   * Signifies success and the end of the action.
+   */
+  success(payload: SuccessPayload): ActionSuccess<SuccessPayload>;
+
+  /**
+   * Signifies permanent failure. The payload type is always unknown because
+   * anything can go wrong.
+   */
+  failure(error: unknown): ActionFailure<unknown>;
+
+  /**
+   * Signifies the start of a long-running task. Can be emitted multiple
+   * times to provide progress updates.
+   */
+  optimistic(payload: OptimisticPayload): OptimisticAction<OptimisticPayload>;
 }

--- a/src/actions/create-action.ts
+++ b/src/actions/create-action.ts
@@ -9,6 +9,7 @@ import {
   ActionFailure,
   VoidAction,
 } from '../types/actions';
+import createActionFactory from './action-factory';
 
 /**
  * Returns a function which generates actions of the given type.
@@ -93,6 +94,9 @@ export default function createAction(actionType: any, effect?: any) {
 //   await http.put('/users/self/profile-photo/', photo)
 // })
 createAction.async = createAsyncAction;
+
+// Advanced usage: action factory for generator functions.
+createAction.factory = createActionFactory;
 
 export type ActionSequence<Action> = Generator<Action, Action>;
 

--- a/src/reducers/__tests__/create-reducer.test.ts
+++ b/src/reducers/__tests__/create-reducer.test.ts
@@ -6,6 +6,7 @@ import { expectType } from '../../types/assertions';
 import forgeAction from '../../utils/forge-action';
 import generatorMiddleware from '../../middleware/generator-middleware';
 import { mixin } from '../../utils/errors';
+import actionFactory from '../../actions/action-factory';
 
 describe('createReducer', () => {
   class KnownError extends mixin(Error) {}
@@ -152,6 +153,20 @@ describe('createReducer', () => {
           expectType<string>(value);
         }),
       ]);
+    });
+
+    it('supports binding reducers to action factory types', () => {
+      const factory = actionFactory<string>('explicit');
+
+      const reducer = createReducer('', (handleAction) => [
+        handleAction(factory, (_state, payload) => {
+          return payload;
+        }),
+      ]);
+
+      const state = reducer(undefined, factory.success('called'));
+
+      expect(state).toBe('called');
     });
   });
 

--- a/src/reducers/__tests__/create-reducer.test.ts
+++ b/src/reducers/__tests__/create-reducer.test.ts
@@ -6,7 +6,6 @@ import { expectType } from '../../types/assertions';
 import forgeAction from '../../utils/forge-action';
 import generatorMiddleware from '../../middleware/generator-middleware';
 import { mixin } from '../../utils/errors';
-import actionFactory from '../../actions/action-factory';
 
 describe('createReducer', () => {
   class KnownError extends mixin(Error) {}
@@ -156,7 +155,7 @@ describe('createReducer', () => {
     });
 
     it('supports binding reducers to action factory types', () => {
-      const factory = actionFactory<string>('explicit');
+      const factory = createAction.factory<string>('explicit');
 
       const reducer = createReducer('', (handleAction) => [
         handleAction(factory, (_state, payload) => {

--- a/src/reducers/__tests__/get-action-type.test.ts
+++ b/src/reducers/__tests__/get-action-type.test.ts
@@ -1,6 +1,5 @@
 import { createAction } from '../../index';
 import getActionType from '../get-action-type';
-import actionFactory from '../../actions/action-factory';
 
 describe('getActionType', () => {
   it('returns the action type', () => {
@@ -23,7 +22,7 @@ describe('getActionType', () => {
   });
 
   it('extracts the action type when given an action factory', () => {
-    const factory = actionFactory('action-type');
+    const factory = createAction.factory('action-type');
 
     expect(getActionType(factory)).toBe('action-type');
   });

--- a/src/reducers/__tests__/get-action-type.test.ts
+++ b/src/reducers/__tests__/get-action-type.test.ts
@@ -1,5 +1,6 @@
 import { createAction } from '../../index';
 import getActionType from '../get-action-type';
+import actionFactory from '../../actions/action-factory';
 
 describe('getActionType', () => {
   it('returns the action type', () => {
@@ -19,6 +20,12 @@ describe('getActionType', () => {
     action.toString = () => 'yo';
 
     expect(getActionType(action as any)).toBe('yo');
+  });
+
+  it('extracts the action type when given an action factory', () => {
+    const factory = actionFactory('action-type');
+
+    expect(getActionType(factory)).toBe('action-type');
   });
 
   it('blows up if you try to pass an unsupported type', () => {

--- a/src/reducers/create-reducer.ts
+++ b/src/reducers/create-reducer.ts
@@ -8,6 +8,7 @@ import { isActionFailure, isOptimisticAction } from '../utils/action-variant';
 import { Action, ActionConstant } from '../types/actions';
 import ReducerType from '../constants/reducer-type';
 import { SuccessPayload, OptimisticPayload } from '../types/payload';
+import { ActionFactory } from '../actions/action-factory';
 
 export default function createReducer<
   State,
@@ -95,7 +96,7 @@ interface HandleAction<State> {
    * })
    */
   <
-    ActionCreator extends (...args: any) => any,
+    ActionCreator extends ActionFactory<any, any> | ((...args: any) => any),
     Reducer extends (
       state: Draft<State>,
       action: SuccessPayload<ActionCreator>,
@@ -116,7 +117,7 @@ interface HandleAction<State> {
    * })
    */
   error<
-    ActionCreator extends (...args: any) => any,
+    ActionCreator extends ActionFactory<any, any> | ((...args: any) => any),
     Reducer extends (state: Draft<State>, error: unknown) => NextState<State>
   >(
     actionCreator: ActionCreator,
@@ -134,7 +135,9 @@ interface HandleAction<State> {
    * })
    */
   optimistic<
-    ActionCreator extends (...args: any) => AsyncGenerator<any, any>,
+    ActionCreator extends
+      | ActionFactory<any, any>
+      | ((...args: any) => AsyncGenerator<any, any>),
     Reducer extends (
       state: Draft<State>,
       action: OptimisticPayload<ActionCreator>,

--- a/src/reducers/get-action-type.ts
+++ b/src/reducers/get-action-type.ts
@@ -1,12 +1,17 @@
 // `createAction(...)` coerces to its action constant. This utility function
 // grabs that constant.
 import { ActionConstant, ActionTypeCoercible } from '../types/actions';
+import { ACTION_TYPE, ActionFactory } from '../actions/action-factory';
 import assert from '../utils/assert';
 
 export default function getActionType(
-  actionCreator: string | ActionTypeCoercible,
+  actionCreator: string | ActionTypeCoercible | ActionFactory<any, any>,
 ): ActionConstant {
   if (typeof actionCreator === 'string') return actionCreator;
+
+  if (ACTION_TYPE in Object(actionCreator)) {
+    return (actionCreator as ActionFactory<any, any>)[ACTION_TYPE];
+  }
 
   assert(
     typeof actionCreator === 'function',

--- a/src/types/__tests__/payload.test.ts
+++ b/src/types/__tests__/payload.test.ts
@@ -1,6 +1,5 @@
 import createAction from '../../actions/create-action';
 import { SuccessPayload, OptimisticPayload } from '../payload';
-import actionFactory from '../../actions/action-factory';
 import { expectType } from '../assertions';
 
 describe('Payload type inference', () => {
@@ -24,7 +23,7 @@ describe('Payload type inference', () => {
     });
 
     it('infers payload types from action factories', () => {
-      const factory = actionFactory<string, number>('type');
+      const factory = createAction.factory<string, number>('type');
 
       expectType<SuccessPayload<typeof factory>>('string');
     });
@@ -45,7 +44,7 @@ describe('Payload type inference', () => {
     });
 
     it('infers payload types from action factories', () => {
-      const factory = actionFactory<number, string>('optimistic');
+      const factory = createAction.factory<number, string>('optimistic');
 
       expectType<OptimisticPayload<typeof factory>>('string');
     });

--- a/src/types/__tests__/payload.test.ts
+++ b/src/types/__tests__/payload.test.ts
@@ -1,0 +1,53 @@
+import createAction from '../../actions/create-action';
+import { SuccessPayload, OptimisticPayload } from '../payload';
+import actionFactory from '../../actions/action-factory';
+import { expectType } from '../assertions';
+
+describe('Payload type inference', () => {
+  describe('SuccessPayload', () => {
+    it('infers void action payloads', () => {
+      const voidAction = createAction('void');
+
+      expectType<SuccessPayload<typeof voidAction>>(undefined);
+    });
+
+    it('infers synchronous action payloads', () => {
+      const plainAction = createAction<string>('plain');
+
+      expectType<SuccessPayload<typeof plainAction>>('input');
+    });
+
+    it('infers synchronous action effect payloads', () => {
+      const effectAction = createAction('effect', () => true);
+
+      expectType<SuccessPayload<typeof effectAction>>(true);
+    });
+
+    it('infers payload types from action factories', () => {
+      const factory = actionFactory<string, number>('type');
+
+      expectType<SuccessPayload<typeof factory>>('string');
+    });
+  });
+
+  describe('OptimisticPayload', () => {
+    it('infers async action creator payloads with no parameters', () => {
+      const effectAction = createAction.async('async', async () => true);
+
+      expectType<OptimisticPayload<typeof effectAction>>(undefined);
+    });
+
+    it('infers async action creator payloads from the effect parameter', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const effectAction = createAction.async('type', async (_t: string) => {});
+
+      expectType<OptimisticPayload<typeof effectAction>>('string');
+    });
+
+    it('infers payload types from action factories', () => {
+      const factory = actionFactory<number, string>('optimistic');
+
+      expectType<OptimisticPayload<typeof factory>>('string');
+    });
+  });
+});

--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -1,23 +1,41 @@
 import { AsyncActionSequence } from '../actions/create-async-action';
 import { ActionSequence } from '../actions/create-action';
 import { VoidAction, ActionSuccess, ActionFailure } from './actions';
+import { ActionFactory } from '../actions/action-factory';
+
+/**
+ * These types are what power the reducer's type inference. They answer the
+ * question "given this action creator, what payload can we expect?"
+ * Because there are many ways to write an action creator, there are many
+ * ways to answer that question. This file tries to enumerate all of them.
+ *
+ * See the test file for a more human-readable overview.
+ */
 
 export type SuccessPayload<
-  Factory extends (...args: any[]) => any
-> = ReturnType<Factory> extends ActionSequence<
-  ActionFailure<unknown> | ActionSuccess<infer Payload>
->
+  Factory extends ActionFactory<any, any> | ((...args: any[]) => any)
+> = Factory extends ActionFactory<infer Payload, any>
   ? Payload
-  : ReturnType<Factory> extends ActionSequence<ActionSuccess<infer Payload>>
-  ? Payload
-  : ReturnType<Factory> extends ActionSequence<VoidAction>
-  ? VoidAction
-  : ReturnType<Factory> extends AsyncActionSequence<any, infer Payload>
-  ? Payload
+  : Factory extends (...args: any[]) => any
+  ? ReturnType<Factory> extends ActionSequence<
+      ActionFailure<unknown> | ActionSuccess<infer Payload>
+    >
+    ? Payload
+    : ReturnType<Factory> extends ActionSequence<ActionSuccess<infer Payload>>
+    ? Payload
+    : ReturnType<Factory> extends ActionSequence<VoidAction>
+    ? VoidAction
+    : ReturnType<Factory> extends AsyncActionSequence<any, infer Payload>
+    ? Payload
+    : never
   : never;
 
 export type OptimisticPayload<
-  Factory extends (...args: any[]) => AsyncGenerator<any>
-> = ReturnType<Factory> extends AsyncActionSequence<infer Payload, any>
+  Factory extends
+    | ActionFactory<any, any>
+    | ((...args: any[]) => AsyncGenerator<any>)
+> = Factory extends ActionFactory<any, infer Payload>
+  ? Payload
+  : Factory extends (...args: any[]) => AsyncActionSequence<infer Payload, any>
   ? Payload
   : never;

--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -24,7 +24,7 @@ export type SuccessPayload<
     : ReturnType<Factory> extends ActionSequence<ActionSuccess<infer Payload>>
     ? Payload
     : ReturnType<Factory> extends ActionSequence<VoidAction>
-    ? VoidAction
+    ? void
     : ReturnType<Factory> extends AsyncActionSequence<any, infer Payload>
     ? Payload
     : never


### PR DESCRIPTION
See issue #217 for details and design considerations.

This PR adds a new action creator type called `createAction.factory(...)`. It allows more fine-grained control within dispatched generator functions without sacrificing type inference.
```ts
const doTheThing = createAction.factory<string, string>('do-the-thing')

async function* thingDoer() {
  yield doTheThing.optimistic('starting to do the thing')

  try {
    yield doTheThing.success('thing done!')
  } catch (error) {
    yield doTheThing.failure(new Error('computer caught fire'))
  }
}

createReducer(0, handleAction => [
  handleAction(doTheThing, (state, msg) => {
    // msg => string
  }),
])
```